### PR TITLE
Add contributor workflow templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: Report a reproducible problem with Checkjebon.nl
+title: ""
+labels: ""
+assignees: ""
+---
+
+## Description
+
+Describe the problem and the behavior you expected.
+
+## Reproduction
+
+List the steps needed to reproduce the problem.
+
+## Environment
+
+- Browser and version:
+- Device or operating system:
+
+## Additional context
+
+Add screenshots or other useful details. Remove personal shopping-list data before posting.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Summary
+
+Describe the change and its user-visible impact.
+
+## Verification
+
+List the browser checks or other verification you performed.
+
+## Checklist
+
+- [ ] I kept the change focused.
+- [ ] I verified the affected workflow in a browser.
+- [ ] I checked a mobile-sized viewport for user-interface changes.
+- [ ] I updated documentation when behavior changed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing to Checkjebon.nl
+
+Thanks for helping improve Checkjebon.nl.
+
+## Before opening a pull request
+
+- Keep changes focused and explain the user-visible impact.
+- Avoid committing secrets, personal shopping lists, or unrelated generated files.
+- Update `README.md` when supported supermarkets or product behavior change.
+- Describe how you verified the change in the pull request.
+
+## Local verification
+
+This repository is a static website. Serve the repository with a local static-file server, open `index.html`, and verify the affected workflow in a browser.
+
+For user-interface changes, check both a desktop-sized viewport and a narrow mobile-sized viewport.
+
+## Reporting bugs
+
+When reporting a bug, include reproduction steps, the browser and device you used, and a screenshot when it helps explain the issue.


### PR DESCRIPTION
This adds lightweight maintainer workflow files:

- `CONTRIBUTING.md` with focused contribution expectations and local browser verification guidance
- `.github/ISSUE_TEMPLATE/bug_report.md` for reproducible bug reports
- `.github/PULL_REQUEST_TEMPLATE.md` for focused PR checks

This follows up on #22. I kept the change limited to documentation and GitHub templates; no application code or product data was changed.

Verification:

- Reviewed the templates locally
- Ran `oss-signal` locally before and after; the maintainer-readiness score improved from 21 to 39 for this repository clone
